### PR TITLE
Fix missing line breaks in example leading to confusion

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -43,11 +43,13 @@ include "includes/navigation.html"
                 </div>
                 <div id="terminal" class="terminal">
                     <code class="code-wrapper"><span class="code-title"># Upload using cURL</span>
-                        $ curl --upload-file ./hello.txt {{.WebAddress}}hello.txt {{.WebAddress}}{{.SampleToken}}/hello.txt
+                        $ curl --upload-file ./hello.txt {{.WebAddress}}hello.txt
+                        {{.WebAddress}}{{.SampleToken}}/hello.txt
 
                         <span class="code-title"># Using the shell function</span>
                         $ transfer hello.txt
-                        ##################################################### 100.0% {{.WebAddress}}{{.SampleToken2}}/hello.txt
+                        ##################################################### 100.0%
+                        {{.WebAddress}}{{.SampleToken2}}/hello.txt
                     </code>
                 </div>
                 <div id="web">


### PR DESCRIPTION
Due to the missing line breaks, the primary example on the homepage may render like this:

> \# Upload using cURL
> $ curl --upload-file ./hello.txt h​ttps://transfer.example.org
> /hello.txt h​ttps://transfer.example.org/66nb8/hello.txt

This may lead to confusion as to where that second URL comes from. Of course, it's the server response, not part of the command line. It just happens to be rendered correctly on the original transfer.sh instance due to the domain name length, which causes the line to break exactly at that point.

The addition of the line breaks at least makes it semantically correct, although it might still render poorly (as above with `/hello.txt` on the new line), so further changes may be needed.