### PR TITLE
Use official GitHub buttons

### DIFF
--- a/src/includes/head.html
+++ b/src/includes/head.html
@@ -9,4 +9,5 @@
     <link href='fonts/fonts.css?family=Source+Sans+Pro:100,200,300' rel='stylesheet' type='text/css'>
     <link href='fonts/fonts.css?family=Droid+Sans+Mono' rel='stylesheet' type='text/css'>
     <script src="scripts/vendor/modernizr.js"></script>
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>

--- a/src/index.html
+++ b/src/index.html
@@ -305,7 +305,7 @@ include "includes/navigation.html"
                     </div>
                 </div>
             </div>
-            
+
             <div class="row">
                 <div class="col-md-6">
                     <h3>Upload a file using Unofficially client in Python</h3>
@@ -335,7 +335,7 @@ include "includes/navigation.html"
                     </div>
                 </div>
             </div>
-            
+
             <div class="row">
                 <div class="col-md-6">
                     <h3>Upload a file or directory in Windows</h3>
@@ -349,8 +349,8 @@ goto main
 :usage
   echo No arguments specified. &gt;&amp;2
   echo Usage: &gt;&amp;2
-  echo   transfer ^&lt;file^|directory^&gt; &gt;&amp;2        
-  echo   ... ^| transfer ^&lt;file_name^&gt; &gt;&amp;2       
+  echo   transfer ^&lt;file^|directory^&gt; &gt;&amp;2
+  echo   ... ^| transfer ^&lt;file_name^&gt; &gt;&amp;2
   exit /b 1
 :main
   if "%~1" == "" goto usage
@@ -378,7 +378,7 @@ goto main
   goto :eof
                         </code>
                     </div>
-                </div>               
+                </div>
                 <div class="col-md-6">
                     <h3>Send us your awesome example</h3>
                     <div class="terminal-top">
@@ -399,8 +399,8 @@ goto main
         <br>
         <br>
 
-        <iframe src="https://ghbtns.com/github-btn.html?user=dutchcoders&repo=transfer.sh&type=follow&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="250" height="50"></iframe>
-        <iframe src="https://ghbtns.com/github-btn.html?user=dutchcoders&repo=transfer.sh&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="200" height="50"></iframe>
+        <a class="github-button" href="https://github.com/dutchcoders" data-size="large" data-show-count="true" aria-label="Follow @dutchcoders on GitHub">Follow @dutchcoders</a>
+        <a class="github-button" href="https://github.com/dutchcoders/transfer.sh" data-size="large" data-show-count="true" aria-label="Star dutchcoders/transfer.sh on GitHub">Star</a>
     </div>
 </section>
 <section id="reviews">


### PR DESCRIPTION
Migrate from `iframe`-based unofficial buttons from https://ghbtns.com/, to the official buttons provided by https://buttons.github.io/

Before:
![image](https://github.com/dutchcoders/transfer.sh-web/assets/3867850/f33180f3-0bd8-4488-828c-21b595962799)

After:
![image](https://github.com/dutchcoders/transfer.sh-web/assets/3867850/ee206845-a112-4ceb-b1fe-968969509551)